### PR TITLE
adding the mac directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *~
 .idea/
 SampleCreateJSPlatform/.metadata/
-SampleCreateJSPlatform/EclipseProject/ExtensionContent/plugin/lib/mac/
 SampleCreateJSPlatform/Plugin/SampleCreateJSPlugin/lib/
 SampleCreateJSPlatform/Plugin/SampleCreateJSPlugin/project/mac/build/
 SampleCreateJSPlatform/RemoteSystemsTempFiles/

--- a/SampleCreateJSPlatform/EclipseProject/ExtensionContent/plugin/lib/mac/.gitignore
+++ b/SampleCreateJSPlatform/EclipseProject/ExtensionContent/plugin/lib/mac/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
adding the mac directory where the .fcm.plugin file gets built but igoring all files inside (other than the gitignore).  the absence of this directory was causing the /Utils/installplugin.sh script to not work.
