### PR TITLE
Support the upcoming version of pixi-animate

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,12 +58,12 @@ var options = {
     runtimeOutput: 'com.jibo.PixiAnimate/runtime',
     runtimeDebugOutput: 'com.jibo.PixiAnimate/runtime-debug',
     runtimeResources: [
-        'node_modules/pixi-animate/dist/pixi.min.js',
+        'node_modules/pixi.js/dist/pixi.min.js',
         'node_modules/pixi-animate/dist/pixi-animate.min.js'
     ],
     runtimeDebugResources: [
-        'node_modules/pixi-animate/dist/pixi.js',
-        'node_modules/pixi-animate/dist/pixi.js.map',
+        'node_modules/pixi.js/dist/pixi.js',
+        'node_modules/pixi.js/dist/pixi.js.map',
         'node_modules/pixi-animate/dist/pixi-animate.js',
         'node_modules/pixi-animate/dist/pixi-animate.js.map'
     ],

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "js-beautify": "^1.6.2",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
-    "pixi-animate": "^0.5.3",
+    "pixi-animate": "^1.0.0",
+    "pixi.js": "^4.2.2",
     "semver": "^5.1.0",
     "uglify-js": "^2.6.1"
   },


### PR DESCRIPTION
* Upgrades to **pixi.js** as a peer dependency of **pixi-animate**

**Requires: https://github.com/jiborobot/pixi-animate/pull/29**