### PR TITLE
Labels not passed to movieclip

### DIFF
--- a/extension/publish/snippets/timeline-tiny.txt
+++ b/extension/publish/snippets/timeline-tiny.txt
@@ -1,5 +1,5 @@
 lib.${id} = MovieClip.e(function() {
-    MovieClip.call(this, 0, ${duration}, true ${labels});
+    MovieClip.call(this, 0, ${duration}, true, 0 ${labels});
     ${contents}
 });
 


### PR DESCRIPTION
Hello, probably you missed framerate parameter in minified version, or you swap framerate with labels in documentation they appear in other order(options, duration, loop, labels, framerate)
class MovieClip extends Container {
    constructor(options, duration, loop, framerate, labels) {