### PR TITLE
Adds reference to the instance name to symbol

### DIFF
--- a/src/extension/publish/instances/Instance.js
+++ b/src/extension/publish/instances/Instance.js
@@ -319,18 +319,8 @@ function equals(a, b)
  */
 p.renderBegin = function()
 {
-    let buffer = "";
-    let instanceName = this.localName;
-
-    // We have an instance name for this, probably movieclip
-    if (this.instanceName)
-    {
-        instanceName += ` = this.${this.instanceName}`;
-    }
-
     // Add the instance name line
-    buffer += `var ${instanceName} = `;
-    return buffer;
+    return `var ${this.localName} = `;
 };
 
 /**
@@ -384,6 +374,13 @@ p.render = function(renderer, mask)
     {
         const func = renderer.compress ? 'ma' : 'setMask';
         buffer += `.${func}(${mask})`;
+    }
+
+    // Add the instance name
+    if (this.instanceName)
+    {
+        buffer += `; ${this.localName}.name = "${this.instanceName}"`;
+        buffer += `; this[${this.localName}.name] = ${this.localName}`;
     }
     return `${buffer};`;
 };

--- a/src/extension/publish/instances/Instance.js
+++ b/src/extension/publish/instances/Instance.js
@@ -379,8 +379,7 @@ p.render = function(renderer, mask)
     // Add the instance name
     if (this.instanceName)
     {
-        buffer += `; ${this.localName}.name = "${this.instanceName}"`;
-        buffer += `; this[${this.localName}.name] = ${this.localName}`;
+        buffer += `; this[${this.localName}.name = "${this.instanceName}"] = ${this.localName}`;
     }
     return `${buffer};`;
 };


### PR DESCRIPTION
### Changed

Modified the instance name setting to allow the name of the symbol to be set reflectively. This approach also accomodates other non alpha-numeric names (e.g., hyphens).

#### Old Approach

Old approach were instance names were set inline when instantiating the new instance.

```js
var instance1 = this.example = new lib.Symbol_1()
    .setTransform(150.45, 85.7);
```
**Minified**
```js
a=this.example=(new e.Symbol_1).t(150.45,85.7);
```
#### New Approach

Here the instance name is declared as a string and the minified code is slightly longer.

```js
var instance1 = new lib.Symbol_1()
    .setTransform(150.45, 85.7);
this[instance1.name = "example"] = instance1;
```
**Minified**
```js
a=(new e.Symbol_1).t(150.45,85.7);this[a.name="example"]=a
```