### PR TITLE
Add library assets path canonicalization when publishing and change windows install path to Program Files (x86)

### DIFF
--- a/build/config/win.js
+++ b/build/config/win.js
@@ -2,7 +2,7 @@ module.exports = {
     pluginTempDebug: 'project/win/pixi-animate-vs2015/x64/Debug/pixi-animate-vs2015.dll',
     pluginTempRelease: 'project/win/pixi-animate-vs2015/x64/Release/pixi-animate-vs2015.dll',
     pluginFile: 'com.jibo.PixiAnimate/plugin/lib/win/PixiAnimate.fcm',
-    installFolder: 'C:\\Program Files\\Common Files\\Adobe\\CEP\\extensions\\com.jibo.PixiAnimate',
+    installFolder: 'C:\\Program Files (x86)\\Common Files\\Adobe\\CEP\\extensions\\com.jibo.PixiAnimate',
     
     // ZXP plugin packaging options
     packager: '.\\build\\bin\\ZXPSignCmd.exe',

--- a/src/PixiAnimate/src/OutputWriter.cpp
+++ b/src/PixiAnimate/src/OutputWriter.cpp
@@ -36,6 +36,7 @@
 #include <sstream>
 #include <string>
 #include <iterator>
+#include <experimental\filesystem>
 #include "FlashFCMPublicIDs.h"
 #include "FCMPluginInterface.h"
 #include "libjson.h"
@@ -55,6 +56,8 @@
 #include "Utils/ILinearColorGradient.h"
 #include <math.h>
 #include "TimelineWriter.h"
+
+namespace fs = std::experimental::filesystem;
 
 #ifdef _WINDOWS
 #include "Windows.h"
@@ -340,7 +343,8 @@ namespace PixiJS
 		if (m_images && bitmapExportService)
 		{
 			FCM::AutoPtr<FCM::IFCMCalloc> pCalloc;
-			FCM::StringRep16 pFilePath = Utils::ToString16(bitmapExportPath, m_pCallback);
+			fs::path exportPath(bitmapExportPath);
+			FCM::StringRep16 pFilePath = Utils::ToString16(fs::canonical(exportPath).string(), m_pCallback);
 			res = bitmapExportService->ExportToFile(pMediaItem, pFilePath, 100);
 			ASSERT(FCM_SUCCESS_CODE(res));
 
@@ -713,6 +717,7 @@ namespace PixiJS
 		FCM::AutoPtr<FCM::IFCMUnknown> pUnk;
 
 		FCM::Boolean alreadyExported = GetImageExportFileName(libPathName, name);
+
 		if (!alreadyExported)
 		{
 			if (m_images && !m_imageFolderCreated)
@@ -745,7 +750,8 @@ namespace PixiJS
 		if (m_images && bitmapExportService)
 		{
 			FCM::AutoPtr<FCM::IFCMCalloc> pCalloc;
-			FCM::StringRep16 pFilePath = Utils::ToString16(bitmapExportPath, m_pCallback);
+			fs::path exportPath(bitmapExportPath);
+			FCM::StringRep16 pFilePath = Utils::ToString16(fs::canonical(exportPath).string(), m_pCallback);
 
 			res = bitmapExportService->ExportToFile(pMediaItem, pFilePath, 100);
 			ASSERT(FCM_SUCCESS_CODE(res));
@@ -969,7 +975,8 @@ namespace PixiJS
 		if (soundExportService)
 		{
 			FCM::AutoPtr<FCM::IFCMCalloc> pCalloc;
-			FCM::StringRep16 pFilePath = Utils::ToString16(soundExportPath, m_pCallback);
+			fs::path exportPath(soundExportPath);
+			FCM::StringRep16 pFilePath = Utils::ToString16(fs::canonical(exportPath).string(), m_pCallback);
 			res = soundExportService->ExportToFile(pMediaItem, pFilePath);
 			ASSERT(FCM_SUCCESS_CODE(res));
 			pCalloc = Utils::GetCallocService(m_pCallback);

--- a/src/PixiAnimate/src/TimelineWriter.cpp
+++ b/src/PixiAnimate/src/TimelineWriter.cpp
@@ -855,6 +855,7 @@ namespace PixiJS
 	FCM::Result TimelineWriter::AddFrameScript(FCM::CStringRep16 pScript, FCM::U_Int32 layerNum)
 	{
 		std::string script = Utils::ToString(pScript, m_pCallback);
+		Utils::ReplaceAll(script, "\r", "");
 		Utils::ReplaceAll(script, "\n", "\\n");
 		Utils::ReplaceAll(script, "\t", "");
 
@@ -962,4 +963,3 @@ namespace PixiJS
 		m_pTimelineElement->push_back(*m_pFrameArray);
 	}
 };
-


### PR DESCRIPTION
Flash(Animate) is looking for extensions in Program Files (x86). Maybe this is a 32bit and 64bit difference issue, but on all the machines I've tested CEP extensions for Flash and Animate, only extensions in Program Files (x86) directory are loaded.