### PR TITLE
Adobe Animate 2017.1 Support

### DIFF
--- a/extension/dialog/host.jsx
+++ b/extension/dialog/host.jsx
@@ -30,4 +30,15 @@ function browseOutputFile() {
     return null;
 }
 
+function getPublishSettings() {
+    var profile = fl.getDocumentDOM().exportPublishProfileString();
+    var settings = /Property name\=\"(PublishSettings\.[^\"]+)\"\>([^\<]+)\<\/Property/g;
+    var result = "";
+    var match = null;
+    while(match = settings.exec(profile)) { // eslint-disable-line no-cond-assign
+        result += '"' + match[1] + '":"' + match[2] + '",';
+    }
+    return '{"data":{' + result.slice(0, -1) + '}}';
+}
+
 /*eslint-enable no-unused-vars */

--- a/src/extension/dialog/index.js
+++ b/src/extension/dialog/index.js
@@ -189,14 +189,12 @@
 
         // Global options
         data["PublishSettings.IncludeInvisibleLayer"] = $hiddenLayers.checked.toString();
-        
-        console.log(data);
 
         var event = new CSEvent();
         event.scope = "APPLICATION";
         event.type = "com.adobe.events.flash.extension.savestate";
         event.data = JSON.stringify(data);
-        event.extensionId = "com.jibo.PixiAnimate.PublishSettings";
+        event.extensionId = csInterface.getExtensionID();
         csInterface.dispatchEvent(event);
     }
 
@@ -274,6 +272,7 @@
     } 
 
     csInterface = new CSInterface();
+    csInterface.setWindowTitle('PixiAnimate Publish Settings');
 
     // Gets the style information such as color info from the skinInfo, 
     // and redraw all UI controls of your extension according to the style info.
@@ -290,14 +289,11 @@
             parentPath = path.dirname(parentPath);
         }
 
-        // Restory the state from the saved settings
+        // Handle set state from the saved settings
         csInterface.addEventListener("com.adobe.events.flash.extension.setstate", restoreState);
-        var event = new CSEvent();
-        event.scope = "APPLICATION";
-        event.type = "com.adobe.events.flash.extensionLoaded";
-        event.data = "Test Event";
-        event.extensionId = "com.jibo.PixiAnimate.PublishSettings";
-        csInterface.dispatchEvent(event);
+        
+        // Restore from publish settings
+        exec('getPublishSettings', restoreState);
     });
 
 }(document, window.__adobe_cep__));


### PR DESCRIPTION
Fixes #38 by working around what is seemingly broken in Adobe Animate 2017.1, publish dialog no longer sets the initial state.